### PR TITLE
Update setup.ipynb with extra step for Cam Hex

### DIFF
--- a/procedures/MT/slew/setup.ipynb
+++ b/procedures/MT/slew/setup.ipynb
@@ -2,6 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "f7f8ee52",
+   "metadata": {},
    "source": [
     "# Main Telescope Slew simulation: Setup notebook\n",
     "\n",
@@ -10,32 +12,36 @@
     "This notebook does slew simulations, and check all aos components (M1M3, M2, hexapods) behavior during the slew-and-track process\n",
     "\n",
     "This is expected to work both for SUMMIT and NCSA"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5d4cb010",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "577821d8",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import rubin_jupyter_utils.lab.notebook as nb\n",
     "nb.utils.get_node()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d0a8eef5",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import os\n",
     "import sys\n",
@@ -47,113 +53,123 @@
     "from matplotlib import pyplot as plt\n",
     "\n",
     "from lsst.ts import salobj\n",
-    "from lsst.ts.observatory.control.maintel.mtcs import MTCS\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "from lsst.ts.observatory.control.maintel.mtcs import MTCS"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "summit = 1 #use this for summit testing\n",
-    "# summit = 0 #use this for NCSA"
-   ],
-   "outputs": [],
+   "id": "09ebccbd",
    "metadata": {
     "tags": [
      "parameter"
     ]
-   }
+   },
+   "outputs": [],
+   "source": [
+    "summit = 1 #use this for summit testing\n",
+    "# summit = 0 #use this for NCSA"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "489785f5",
+   "metadata": {},
    "source": [
     "## Check environment setup\n",
     "\n",
     "The following cell will print some of the basic DDS configutions."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e0332e1c",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(os.environ[\"OSPL_URI\"])\n",
     "print(os.environ[\"LSST_DDS_PARTITION_PREFIX\"])\n",
     "print(os.environ.get(\"LSST_DDS_DOMAIN_ID\", \"Expected, not set.\"))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "68270f67",
+   "metadata": {},
    "source": [
     "### Setup logging\n",
     "\n",
     "Setup logging in debug mode and create a logger to use on the notebook."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "10564a81",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "logging.basicConfig(format=\"%(name)s:%(message)s\", level=logging.DEBUG)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2d672a06",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "log = logging.getLogger(\"setup\")\n",
     "log.level = logging.DEBUG"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8d28d522",
+   "metadata": {},
    "source": [
     "# Starting communication resources\n",
     "\n",
     "We start by creating a domain and later instantiate the MTCS class.\n",
     "We will use the class to startup the components. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c7dd9df7",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "domain = salobj.Domain()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d61145c4",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mtcs = MTCS(domain=domain, log=log)\n",
     "mtcs.set_rem_loglevel(40)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ab646382",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.start_task"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8f57ec86",
+   "metadata": {},
    "source": [
     "# Starting components\n",
     "\n",
@@ -162,11 +178,12 @@
     "\n",
     "The answer is that the MTCS components have some initilization dependencies that need to be observed for the components to be enabled properly.\n",
     "We will describe these as we work our way the initialization steps.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "294e7f0e",
+   "metadata": {},
    "source": [
     "## Starting MTPtg\n",
     "\n",
@@ -179,29 +196,32 @@
     "It is also worth noticed that, as a pure-software component, the `MTPtg` does not have a simulation mode.\n",
     "\n",
     "Furthermore, as you will notice below, we are not checking the software version of the `MTPtg`, mainly because the component is currently not sending this information."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "56bfe634",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.next_heartbeat(\"mtptg\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a4f92bbe",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.set_state(salobj.State.ENABLED, components=[\"mtptg\"])"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b74e14fb",
+   "metadata": {},
    "source": [
     "## Starting MTMount\n",
     "\n",
@@ -210,43 +230,48 @@
     "The MTMount needs to be enabled before we enable the MTRotator.\n",
     "The reason is that the MTRotator needs to know the position of the Camera Cable Wrap (CCW), which is provided by the MTMount, before it can be enable. \n",
     "If the MTRotator does not receive the position of the CCW, it will immediatelly activate the breaks and transition to FAULT state."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "9336399e",
+   "metadata": {},
    "source": [
     "We start by verifying that the CSC is sending heartbeats."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "588d57cb",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.next_heartbeat(\"mtmount\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e991636b",
+   "metadata": {},
    "source": [
     "Now we can enable the CSC."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a633a085",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.set_state(salobj.State.ENABLED, components=[\"mtmount\"])"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "42aa2672",
+   "metadata": {},
    "source": [
     "### Perform some basic checks\n",
     "\n",
@@ -255,12 +280,14 @@
     "We check if the CSC is running in simulation mode and then the version of the CSC.\n",
     "\n",
     "Finally, we verify that the camera cable wrap following is enabled."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8b7f77a9",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mtmount_simulation_mode = await mtcs.get_simulation_mode([\"mtmount\"])\n",
     "\n",
@@ -270,13 +297,14 @@
     "log.debug(\n",
     "    f\"MTMount simulation mode: {mode} @ {timestamp}\"\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "488b8ee0",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mtmount_software_versions = await mtcs.get_software_versions([\"mtmount\"])\n",
     "\n",
@@ -286,13 +314,14 @@
     "log.debug(\n",
     "    f\"MTMount software version: {csc_version} @ {timestamp}\",\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "345f8701",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mtmount_ccw_following = await mtcs.rem.mtmount.evt_cameraCableWrapFollowing.aget()\n",
     "\n",
@@ -308,47 +337,52 @@
     "        \"make sure the MTRotator telemetry is being published, then execute the procedure again. \"\n",
     "        \"MTMount CSC will be left in DISABLED state.\"\n",
     "        )\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "879e312a",
+   "metadata": {},
    "source": [
     "## Starting Rotator"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b8b856d9",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.next_heartbeat(\"mtrotator\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ad5ea0b7",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.set_state(salobj.State.ENABLED, components=[\"mtrotator\"])"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b1d0e1b4",
+   "metadata": {},
    "source": [
     "### Perform some basic checks\n",
     "\n",
     "The following is a few sanity checks we routinely perform to verify the system integrity at this stage."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5ef8c277",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mtrotator_simulation_mode = await mtcs.get_simulation_mode([\"mtrotator\"])\n",
     "\n",
@@ -358,13 +392,14 @@
     "log.debug(\n",
     "    f\"MTRotator simulation mode: {mode} @ {timestamp}\"\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f9c491be",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mtrotator_software_versions = await mtcs.get_software_versions([\"mtrotator\"])\n",
     "\n",
@@ -374,13 +409,14 @@
     "log.debug(\n",
     "    f\"MTRotator software version: {csc_version} @ {timestamp}\",\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "95e20a52",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "elevation = await mtcs.rem.mtmount.tel_elevation.next(flush=True, timeout=5)\n",
     "azimuth = await mtcs.rem.mtmount.tel_azimuth.next(flush=True, timeout=5)\n",
@@ -391,12 +427,12 @@
     "log.info(f\"mount azimuth angle = {azimuth.actualPosition}\")\n",
     "log.info(f\"CCW angle = {ccw.actualPosition}. Needs to be within 2.2 deg of rotator angle \")\n",
     "log.info(f\"rot angle = {rotator.actualPosition} diff = {rotator.actualPosition - ccw.actualPosition}\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e1a23c80",
+   "metadata": {},
    "source": [
     "### CCW telemetry too old\n",
     "\n",
@@ -411,12 +447,14 @@
     "You can use the cell below to determine whether this is the case or not.\n",
     "If so, you need to contact IT or someone with knowledge about the `MTMount` low level controller to fix the time synchronization issue.\n",
     "\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7b8d52af",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "ccw = await mtcs.rem.mtmount.tel_cameraCableWrap.next(flush=True, timeout=5)\n",
     "rotator = await mtcs.rem.mtrotator.tel_rotation.next(flush=True, timeout=5)\n",
@@ -443,91 +481,99 @@
     "        f\"CCW timestamp out of sync by {abs(ccw_snd_stamp - ccw_timestamp)}s. \"\n",
     "        \"System may not work. Check clock synchronization in MTMount low level controller.\"\n",
     "        )"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ee8f02c6",
+   "metadata": {},
    "source": [
     "### Clearing error in MTRotator\n",
     "\n",
     "If the MTRotator is in FAULT state, you need to send the `clearError` command before transitioning it back to `ENABLED`.\n",
     "\n",
     "This is a particularity of the `MTRotator` (and `MTHexapod`) that violates our state machine."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2bea664e",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "if False:\n",
     "    await mtcs.rem.mtrotator.cmd_clearError.set_start()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "c592738b",
+   "metadata": {},
    "source": [
     "## Checkpoint\n",
     "\n",
     "At this point the system is ready for exercicing slew activities, without involving the optical components."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "12d7dc71",
+   "metadata": {},
    "source": [
     "## Starting M1M3 (Mount telemetry mode)"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "7d69ff05",
+   "metadata": {},
    "source": [
     "If running the test on level 3 and if M1M3 is configured to listen for the mount telemetry, we firt need to make sure the `MTMount` is pointing to zenith.\n",
     "\n",
     "The reason is that `M1M3` is in a fixed position and, when we try to enabled/raise it, the will check the inclinometer data against the elevation data. If they differ by more than a couple degrees the process will fail.\n",
     "\n",
     "Once M1M3 is mounted on the telescope and we are operating the actual mount, instead of in simulation mode, this will not be necessary."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e0bc8ef4",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.rem.mtmount.cmd_moveToTarget.set_start(azimuth=0, elevation=90)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d72f67f8",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.next_heartbeat(\"mtm1m3\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3005d493",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.set_state(\n",
     "    state=salobj.State.ENABLED,\n",
     "    settings=dict(mtm1m3=\"Default\"),\n",
     "    components=[\"mtm1m3\"]\n",
     "    )"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "aa8c54a8",
+   "metadata": {},
    "source": [
     "### Raise m1m3\n",
     "\n",
@@ -539,102 +585,113 @@
     "Once you execute the cell bellow you will notice that the log messages will appear below the cell, but you can also see that the cell will be masked as \"finished executing\".\n",
     "That means, instead of seeing an `*` you will see the number of the cell.\n",
     "This is because the operation is running in the background and we have control over the notebook to execute additional cells."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0b4c7643",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "task_raise_m1m3 = asyncio.create_task(mtcs.raise_m1m3())"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "7940dfca",
+   "metadata": {},
    "source": [
     "The next cell contain a command to abort the raise operation initiated in the background on the cell above.\n",
     "Note that the command to execute the abort operation is encapsulated by an `if False`.\n",
     "This is to prevent the command from executing if the notebook is being executed by papermill or by accident.\n",
     "\n",
     "If you need to abort the operation change the if statement to `if True`."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8700b7f4",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "if False:\n",
     "    await mtcs.abort_raise_m1m3()\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1f809804",
+   "metadata": {},
    "source": [
     "The next cell will wait for the raise_m1m3 command to finish executing. \n",
     "This is to make sure a batch processing of the notebook won't proceed until the raise operation is completed."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "869883db",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await task_raise_m1m3"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a208a3ea",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.enable_m1m3_balance_system()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d9adb95f",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.reset_m1m3_forces()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a681bc7a",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Move this to a shutdown notebook...\n",
     "# await lowerM1M3(m1m3)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "666bf908",
+   "metadata": {},
    "source": [
     "## Starting M2"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f5d110af",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.next_heartbeat(\"mtm2\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "6e63aa64",
+   "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "Remember to reset interlocks.\n",
@@ -646,127 +703,140 @@
     "To work around it we will do them one at a time, adding a sleep between each of them to allow the CSC to finish the state transition.\n",
     "\n",
     "These workarounds should be removed once the CSC is fixed."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8bd77af7",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.set_state(\n",
     "    state=salobj.State.STANDBY,\n",
     "    components=[\"mtm2\"]\n",
     "    )"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e6423465",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mtm2_state_transition_sleep_time = 5."
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "844aa64e",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await asyncio.sleep(mtm2_state_transition_sleep_time)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6eb2aa40",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.set_state(\n",
     "    state=salobj.State.DISABLED,\n",
     "    components=[\"mtm2\"]\n",
     "    )"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c21ad478",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await asyncio.sleep(mtm2_state_transition_sleep_time)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b2c6e355",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.set_state(\n",
     "    state=salobj.State.ENABLED,\n",
     "    components=[\"mtm2\"]\n",
     "    )"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3c91e38d",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "if False:\n",
     "    await mtcs.rem.mtm2.cmd_clearErrors.set_start(timeout=15.)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d6d68cd5",
+   "metadata": {},
    "source": [
     "### Prepare M2 for operation\n",
     "\n",
     "Switch on m2 force balance system and reset m2 forces."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b3f06f53",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.enable_m2_balance_system()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "41895459",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.reset_m2_forces()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "82d63b54",
+   "metadata": {},
    "source": [
     "## Starting Camera Hexapod"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4cd84fe4",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.next_heartbeat(\"mthexapod_1\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ae453442",
+   "metadata": {},
    "source": [
     "The command bellow to enable the Camera Hexapod should work, in general. \n",
     "Nevertheless, we found an issue with the interaction between the low level controller and the CSC that was causing it to fail from time to time.\n",
@@ -775,25 +845,60 @@
     "\n",
     "Until this ticket is worked on you may encounter failures when executing the cell below.\n",
     "You can continue by running the cell again."
-   ],
-   "metadata": {}
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68af1d7f-002c-4895-a49c-7221e0baef68",
+   "metadata": {},
+   "source": [
+    "In addition to the ticket above, the software of camera hexapod controller and EUI v1.2.0 on summit require the `mthexapod_1` to be in `DISABLED` state when setting the command source to DDS/CSC.  "
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7ca3e75d-665d-4566-b18b-0a68c9cabbb5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "await salobj.set_summary_state(\n",
+    "    mtcs.rem.mthexapod_1, \n",
+    "    salobj.State.DISABLED, \n",
+    "    settingsToApply=\"default\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d0d1ea3-b841-41ad-9bc3-9137f79ada9d",
+   "metadata": {},
+   "source": [
+    "Set the **Source Command in the EUI to DDS** regardless the EUI State."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "653e99a0",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.set_state(\n",
     "    state=salobj.State.ENABLED,\n",
     "    settings=dict(mthexapod_1=\"default\"),\n",
     "    components=[\"mthexapod_1\"]\n",
     "    )"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fb2c6734",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mthexapod_1_simulation_mode = await mtcs.get_simulation_mode([\"mthexapod_1\"])\n",
     "\n",
@@ -803,13 +908,14 @@
     "log.debug(\n",
     "    f\"Camera Hexapod simulation mode: {mode} @ {timestamp}\"\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "aa851b0f",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mthexapod_1_software_versions = await mtcs.get_software_versions([\"mthexapod_1\"])\n",
     "\n",
@@ -819,78 +925,86 @@
     "log.debug(\n",
     "    f\"Camera Hexapod software version: {csc_version} @ {timestamp}\",\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0ab0ad77",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "if False:\n",
     "    await mtcs.rem.mthexapod_1.cmd_clearError.set_start()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8bba7a59",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.enable_compensation_mode(component=\"mthexapod_1\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5225b012",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.reset_camera_hexapod_position()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ce47ee84",
+   "metadata": {},
    "source": [
     "## Starting M2 Hexapod"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fbbafead",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.next_heartbeat(\"mthexapod_2\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "bfee5c6b",
+   "metadata": {},
    "source": [
     "We have been mostly running the M2 Hexapod in simulation mode, because the actual hardware is mounted on the telescope.\n",
     "This means the M2 Hexapod is not affected by the issue we reported above for the Camera Hexapod."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d6597e6f",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.set_state(\n",
     "    state=salobj.State.ENABLED,\n",
     "    settings=dict(mthexapod_2=\"default\"),\n",
     "    components=[\"mthexapod_2\"]\n",
     "    )"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b309c4f0",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mthexapod_2_simulation_mode = await mtcs.get_simulation_mode([\"mthexapod_2\"])\n",
     "\n",
@@ -900,13 +1014,14 @@
     "log.debug(\n",
     "    f\"M2 Hexapod simulation mode: {mode} @ {timestamp}\"\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7d915b43",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mthexapod_2_software_versions = await mtcs.get_software_versions([\"mthexapod_2\"])\n",
     "\n",
@@ -916,52 +1031,55 @@
     "log.debug(\n",
     "    f\"M2 Hexapod software version: {csc_version} @ {timestamp}\",\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c23b25ae",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.enable_compensation_mode(component=\"mthexapod_2\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a31717c3",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.reset_camera_hexapod_position()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "3384ca19",
+   "metadata": {},
    "source": [
     "# Closing MTCS and Domain\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "66bd3b34",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await mtcs.close()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f0f6b648",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "await domain.close()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {
@@ -981,7 +1099,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.8"
-  }
+  },
+  "toc-autonumbering": false,
+  "toc-showmarkdowntxt": false
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/procedures/MT/slew/setup.ipynb
+++ b/procedures/MT/slew/setup.ipynb
@@ -1064,6 +1064,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "989225a6-c3ba-40dd-aeba-3f5b2e5d90ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await mtcs.enable()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "66bd3b34",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
The software of the camera hexapod controller and EUI on the summit were updated recently. Both of them are in the version of 1.2.0 now.

Now the CSC needs to be in `DISABLED` state to take over control from the EUI. The `setup.ipynb` notebook needs to be updated to match this new behavior.