### PR TITLE
Add notebook to plot results from LVV-2190 test

### DIFF
--- a/procedures/LVV-P81/LVV-C176/LVV-T2190-plots.ipynb
+++ b/procedures/LVV-P81/LVV-C176/LVV-T2190-plots.ipynb
@@ -1,0 +1,1356 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2675f162",
+   "metadata": {},
+   "source": [
+    "# LVV-T2190 Plots\n",
+    "\n",
+    "This notebook is designed to query the EFD and make diagnostics plots for the execution of Test Case [LVV-T2190].  \n",
+    "This test case consists of applying `1 um` to the 7th component of the Annular Zernike Coefficient.  \n",
+    "Then it resets the corrections and applies `2 um` to the same component. \n",
+    "\n",
+    "This means that we can expect to have three values for each metric (at +1um, at 0um, and at +2um).  \n",
+    "We can expect that that each telemetry on the third row will be twice the values of the first row.  \n",
+    "If they are not, it can mean that the corrections are not properly calculated or that their relationship with the Zernike Coefficients are not linear.\n",
+    "\n",
+    "When executing the tests, duplicate the notebook and rename it using the test execution name.\n",
+    "\n",
+    "[LVV-T2190]: https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/LVV-T2190"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fb05c82-00e6-4662-9883-3cbb4e82f4fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lsst.ts import utils\n",
+    "\n",
+    "# Extract your name from the Jupyter Hub\n",
+    "__executed_by__ = os.environ[\"JUPYTERHUB_USER\"]  \n",
+    "\n",
+    "# Extract execution date\n",
+    "__executed_on__ = utils.astropy_time_from_tai_unix(utils.current_tai())\n",
+    "__executed_on__.format = \"isot\"\n",
+    "\n",
+    "# This is used later to define where Butler stores the images\n",
+    "summit = os.environ[\"LSST_DDS_PARTITION_PREFIX\"] == \"summit\"\n",
+    "\n",
+    "print(f\"\\nExecuted by {__executed_by__} on {__executed_on__}.\"\n",
+    "      f\"\\n  At the summit? {summit}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3691c21",
+   "metadata": {},
+   "source": [
+    "## Set Up "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b8f205c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os \n",
+    "import sys\n",
+    "import logging\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from astropy.time import Time\n",
+    "from astropy import units as u\n",
+    "from datetime import timedelta, datetime\n",
+    "\n",
+    "import lsst_efd_client\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import LogNorm\n",
+    "\n",
+    "from pandas.plotting import register_matplotlib_converters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "963a90a0-d6b9-4922-b30f-cc5a1484ef38",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%config Application.log_level=\"DEBUG\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9c8c689",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e9cb52f-97d5-477f-bc9c-cc44997325e5",
+   "metadata": {},
+   "source": [
+    "## Time window for the test execution.\n",
+    "\n",
+    "Update the cells below to reflect the time when the test was executed.  \n",
+    "This is the time window used to query the EFD.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6fbe593-1c58-4199-beeb-6f58bdcb58f1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "test_execution = \"LVV-E1693\"\n",
+    "time_start_utc = \"2022-03-29T21:00:00\"\n",
+    "time_end_utc = \"2022-03-29T21:02:00\"\n",
+    "\n",
+    "# test_execution = \"LVV-E1788\"\n",
+    "# time_start_utc = \"2022-04-08T14:20:42\"\n",
+    "# time_end_utc = \"2022-04-08T15:21:31\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10c391ae-9947-4f06-baaa-fa883ef40684",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "start = Time(time_start_utc, format=\"isot\", scale=\"utc\")\n",
+    "end = Time(time_end_utc, format=\"isot\", scale=\"utc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98ee1118",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "We start by setting up a logger for the notebook and configuring the EFD Client."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "297ef5bf",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "log = logging.getLogger(\"LVV-T2190\")\n",
+    "log.setLevel(logging.DEBUG)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a37d87a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "lsst_efd_client.EfdClient.list_efd_names()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f34a260",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "efd_name = \"summit_efd\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6516fcc5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "client = lsst_efd_client.EfdClient(efd_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96913d8b-0aad-4dc4-a300-f1882ddd906b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "start.strftime(\"%m/%d/%Y, %H:%M:%S\"), end.strftime(\"%m/%d/%Y, %H:%M:%S\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "429e65fa",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "log.debug(f\"{start.utc}, {end}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f496595-49bd-46f0-b577-728dcfee242d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.makedirs(\"plots\", exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2238412",
+   "metadata": {},
+   "source": [
+    "## Displaying results\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7941bbe2",
+   "metadata": {},
+   "source": [
+    "### Display degrees of freedom\n",
+    "\n",
+    "The degrees of freedom are the first step performed by the OFC in converting the wavefront errors into corrections. \n",
+    "\n",
+    "It is composed of two parts, the \"aggregated\" and the \"visit\" degrees of freedom.\n",
+    "The \"aggregated\" is the combination of all corrections computed so far whereas the \"visit\" contains only the degrees of freedom from the last correction.\n",
+    "\n",
+    "These values are published as vectors of 50 elements each in the \"degreeOfFreedom\" event.\n",
+    "As with the `annularZernikeCoeff` case above we need to query them individually and then build the vectors afterwards."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f26c3ef5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "degrees_of_freedom = await client.select_time_series(\n",
+    "    'lsst.sal.MTAOS.logevent_degreeOfFreedom', \n",
+    "    [f\"aggregatedDoF{i}\" for i in range(50)] + [f\"visitDoF{i}\" for i in range(50)], \n",
+    "    start.utc, \n",
+    "    end.utc\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f82d6607",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "degrees_of_freedom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8785dd3b-eb1c-4c6f-bc4e-37e26a3b7003",
+   "metadata": {},
+   "source": [
+    "During the [LVV-T2190] test, we first issue an `1 um` aberration, reset the the corrections, and then issue a `2 um` aberration.  \n",
+    "Common sense says that row 2 and row 0 must have a factor of 2 of difference. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47aae5ef-5d49-4644-9de1-0b2fc4b22dfe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "degrees_of_freedom.iloc[2] / degrees_of_freedom.iloc[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff8dfa60",
+   "metadata": {},
+   "source": [
+    "We need to unpack the data from the EFD query into vectors that are easier to plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "193ebe0f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "aggregated_dof = np.array([degrees_of_freedom[f\"aggregatedDoF{i}\"] for i in range(50)]).T\n",
+    "visit_dof = np.array([degrees_of_freedom[f\"visitDoF{i}\"] for i in range(50)]).T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ec40cd1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "comp_dof_idx = dict(\n",
+    "            m2HexPos=dict(\n",
+    "                startIdx=0,\n",
+    "                idxLength=5,\n",
+    "                state0name=\"M2Hexapod\",\n",
+    "            ),\n",
+    "            camHexPos=dict(\n",
+    "                startIdx=5,\n",
+    "                idxLength=5,\n",
+    "                state0name=\"cameraHexapod\",\n",
+    "            ),\n",
+    "            M1M3Bend=dict(\n",
+    "                startIdx=10, idxLength=20, state0name=\"M1M3Bending\", rot_mat=1.0\n",
+    "            ),\n",
+    "            M2Bend=dict(startIdx=30, idxLength=20, state0name=\"M2Bending\", rot_mat=1.0),\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed479a54",
+   "metadata": {},
+   "source": [
+    "And we finally plot them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d3fc836",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(2,2, figsize=(10,6), dpi=90)\n",
+    "\n",
+    "for i in range(len(aggregated_dof)):\n",
+    "    \n",
+    "    axes[0][0].plot(\n",
+    "        aggregated_dof[i][\n",
+    "            comp_dof_idx[\"m2HexPos\"][\"startIdx\"]:\n",
+    "            comp_dof_idx[\"m2HexPos\"][\"startIdx\"]+comp_dof_idx[\"m2HexPos\"][\"idxLength\"]\n",
+    "        ]\n",
+    "    )\n",
+    "    \n",
+    "    axes[0][1].plot(\n",
+    "        aggregated_dof[i][\n",
+    "            comp_dof_idx[\"camHexPos\"][\"startIdx\"]:\n",
+    "            comp_dof_idx[\"camHexPos\"][\"startIdx\"]+comp_dof_idx[\"camHexPos\"][\"idxLength\"]\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "    axes[1][0].plot(\n",
+    "        aggregated_dof[i][\n",
+    "            comp_dof_idx[\"M2Bend\"][\"startIdx\"]:\n",
+    "            comp_dof_idx[\"M2Bend\"][\"startIdx\"]+comp_dof_idx[\"M2Bend\"][\"idxLength\"]\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "    axes[1][1].plot(\n",
+    "        aggregated_dof[i][\n",
+    "            comp_dof_idx[\"M1M3Bend\"][\"startIdx\"]:\n",
+    "            comp_dof_idx[\"M1M3Bend\"][\"startIdx\"]+comp_dof_idx[\"M1M3Bend\"][\"idxLength\"]\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "ax_titles = [\"M2 Hexapod DoF\",  \"Camera Hexapod DoF\", \"M2 DoF\", \"M1M3 DoF\"]\n",
+    "for i in range(4):\n",
+    "\n",
+    "    r = i // 2\n",
+    "    c = i % 2\n",
+    "\n",
+    "    axes[r][c].set_title(ax_titles[i])\n",
+    "    axes[r][c].set_xlabel(\"axis\")\n",
+    "    axes[r][c].set_ylabel(\"dof\")\n",
+    "    axes[r][c].grid(\"-\", alpha=0.2)\n",
+    "\n",
+    "fig.suptitle(f\"{test_execution} - Degrees of Freedom\")\n",
+    "fig.patch.set_facecolor('white')\n",
+    "plt.subplots_adjust(hspace=0.4, wspace=0.3)\n",
+    "\n",
+    "fig.savefig(f\"plots/{test_execution}_dof.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07c4ad28",
+   "metadata": {},
+   "source": [
+    "## Step 8"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c50ce4e",
+   "metadata": {},
+   "source": [
+    "### Display Camera Hexapod Correction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00183c26",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cam_hexapod_correction_computed_xyz = await client.select_time_series(\n",
+    "    'lsst.sal.MTAOS.logevent_cameraHexapodCorrection', \n",
+    "    [\"x\", \"y\", \"z\"], \n",
+    "    start.utc, \n",
+    "    end.utc\n",
+    ")\n",
+    "\n",
+    "cam_hexapod_correction_computed_uv = await client.select_time_series(\n",
+    "    'lsst.sal.MTAOS.logevent_cameraHexapodCorrection', \n",
+    "    [\"u\", \"v\"], \n",
+    "    start.utc, \n",
+    "    end.utc\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db395119",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cam_hexapod_correction_applied_xyz = await client.select_time_series(\n",
+    "    'lsst.sal.MTHexapod.logevent_uncompensatedPosition', \n",
+    "    [\"x\", \"y\", \"z\", \"MTHexapodID\"], \n",
+    "    start.utc, \n",
+    "    end.utc,\n",
+    "    index=1\n",
+    ")\n",
+    "\n",
+    "cam_hexapod_correction_applied_uv = await client.select_time_series(\n",
+    "    'lsst.sal.MTHexapod.logevent_uncompensatedPosition', \n",
+    "    [\"u\", \"v\", \"MTHexapodID\"], \n",
+    "    start.utc, \n",
+    "    end.utc,\n",
+    "    index=1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a00089d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cam_hexapod_correction_command_xyz = await client.select_time_series(\n",
+    "    'lsst.sal.MTHexapod.command_move', \n",
+    "    [\"x\", \"y\", \"z\", \"MTHexapodID\"], \n",
+    "    start.utc, \n",
+    "    end.utc,\n",
+    "    index=1\n",
+    ")\n",
+    "\n",
+    "cam_hexapod_correction_command_uv = await client.select_time_series(\n",
+    "    'lsst.sal.MTHexapod.command_move', \n",
+    "    [\"u\", \"v\", \"MTHexapodID\"], \n",
+    "    start.utc, \n",
+    "    end.utc,\n",
+    "    index=1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3c79f02",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cam_hexapod_correction_computed_xyz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aefe5dbb-6cad-446c-a593-0dc2a8ee08e5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cam_hexapod_correction_computed_uv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48198773",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cam_hexapod_correction_applied_xyz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b46273bf-fe57-4b09-a671-aebeb032d855",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cam_hexapod_correction_applied_uv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a73a880",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cam_hexapod_correction_command_xyz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ba857b0-70be-4bd3-a7c7-0cb53b90fc47",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cam_hexapod_correction_command_uv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "047d6ced",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(figsize=(14, 6), ncols=5)\n",
+    "\n",
+    "for panel, label in enumerate(\"xyz\"):\n",
+    "\n",
+    "    ax = plt.subplot(1,5,panel+1)\n",
+    "\n",
+    "    ax.bar(\n",
+    "        [-0.5],\n",
+    "        cam_hexapod_correction_computed_xyz[label],\n",
+    "        width=0.5\n",
+    "    )\n",
+    "    ax.bar(    \n",
+    "        [0.],\n",
+    "        cam_hexapod_correction_applied_xyz[label],\n",
+    "        width=0.5\n",
+    "    )\n",
+    "\n",
+    "    ax.bar(    \n",
+    "        [0.5],\n",
+    "        cam_hexapod_correction_command_xyz[label],\n",
+    "        width=0.5\n",
+    "    )\n",
+    "    \n",
+    "    ax.set_xticks([0])\n",
+    "    ax.set_xticklabels([label])\n",
+    "    ax.set_ylabel(\"Position (micron)\")\n",
+    "\n",
+    "for panel, label in enumerate(\"uv\"):\n",
+    "\n",
+    "    ax = plt.subplot(1,5,panel+4)\n",
+    "    \n",
+    "    x = [0.]\n",
+    "\n",
+    "    b0 = ax.bar(\n",
+    "        [-0.5],\n",
+    "        cam_hexapod_correction_computed_uv[label],\n",
+    "        width=0.5,\n",
+    "    )\n",
+    "    \n",
+    "    b1 = ax.bar(    \n",
+    "        [0.],\n",
+    "        cam_hexapod_correction_applied_uv[label],\n",
+    "        width=0.5, \n",
+    "    )\n",
+    "\n",
+    "    b2 = ax.bar(    \n",
+    "        [0.5],\n",
+    "        cam_hexapod_correction_command_uv[label],\n",
+    "        width=0.5, \n",
+    "    )\n",
+    "\n",
+    "    ax.set_xticks([0])\n",
+    "    ax.set_xticklabels([label])\n",
+    "    ax.set_ylabel(\"Position (degrees)\")\n",
+    "    \n",
+    "fig.suptitle(f\"{test_execution} - Camera Hexapod\\nComputed/Applied/Commanded Corrections\")\n",
+    "fig.tight_layout(h_pad=0.3)\n",
+    "fig.patch.set_facecolor('white')\n",
+    "\n",
+    "fig.savefig(f\"plots/{test_execution}_camera_hexapod.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "458f35ec",
+   "metadata": {},
+   "source": [
+    "### Display M2 Hexapod Correction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e03d1997",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "m2_hexapod_correction_computed_xyz = await client.select_time_series(\n",
+    "    'lsst.sal.MTAOS.logevent_m2HexapodCorrection', \n",
+    "    [\"x\", \"y\", \"z\"], \n",
+    "    start.utc, \n",
+    "    end.utc\n",
+    ")\n",
+    "\n",
+    "m2_hexapod_correction_computed_uv = await client.select_time_series(\n",
+    "    'lsst.sal.MTAOS.logevent_m2HexapodCorrection', \n",
+    "    [\"u\", \"v\"], \n",
+    "    start.utc, \n",
+    "    end.utc\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88c1d0b7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "m2_hexapod_correction_applied_xyz = await client.select_time_series(\n",
+    "    'lsst.sal.MTHexapod.logevent_uncompensatedPosition', \n",
+    "    [\"x\", \"y\", \"z\", \"MTHexapodID\"], \n",
+    "    start.utc, \n",
+    "    end.utc,\n",
+    "    index=2\n",
+    ")\n",
+    "\n",
+    "m2_hexapod_correction_applied_uv = await client.select_time_series(\n",
+    "    'lsst.sal.MTHexapod.logevent_uncompensatedPosition', \n",
+    "    [\"u\", \"v\", \"MTHexapodID\"], \n",
+    "    start.utc, \n",
+    "    end.utc,\n",
+    "    index=2\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78033402",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "m2_hexapod_correction_command_xyz = await client.select_time_series(\n",
+    "    'lsst.sal.MTHexapod.command_move', \n",
+    "    [\"x\", \"y\", \"z\", \"MTHexapodID\"], \n",
+    "    start.utc, \n",
+    "    end.utc,\n",
+    "    index=2\n",
+    ")\n",
+    "\n",
+    "m2_hexapod_correction_command_uv = await client.select_time_series(\n",
+    "    'lsst.sal.MTHexapod.command_move', \n",
+    "    [\"u\", \"v\", \"MTHexapodID\"], \n",
+    "    start.utc, \n",
+    "    end.utc,\n",
+    "    index=2\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d9971e7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "m2_hexapod_correction_command_xyz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7cfce0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2_hexapod_correction_computed_xyz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cffe27cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2_hexapod_correction_applied_xyz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c68ddad0-c79a-4fd8-abd4-4b7a40977933",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2_hexapod_correction_command_uv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e878286e-5c75-496c-b9cf-c5694bb38c4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2_hexapod_correction_computed_uv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d84e78e-f3ae-421a-bf84-1a3f1f94f405",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2_hexapod_correction_applied_uv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2902c87a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(figsize=(16, 6), ncols=5)\n",
+    "\n",
+    "for panel, label in enumerate(\"xyz\"):\n",
+    "\n",
+    "    ax = axs[panel]\n",
+    "    \n",
+    "    ax.bar(\n",
+    "        [-0.5],\n",
+    "        m2_hexapod_correction_computed_xyz[label],\n",
+    "        width=0.5\n",
+    "    )\n",
+    "    \n",
+    "    ax.bar(    \n",
+    "        [0.],\n",
+    "        m2_hexapod_correction_applied_xyz[label],\n",
+    "        width=0.5\n",
+    "    )\n",
+    "\n",
+    "    ax.bar(    \n",
+    "        [0.5],\n",
+    "        m2_hexapod_correction_command_xyz[label],\n",
+    "        width=0.5\n",
+    "    )\n",
+    "\n",
+    "    ax.set_xticks([0])\n",
+    "    ax.set_xticklabels([label])\n",
+    "    ax.set_ylabel(\"Position (micron)\")\n",
+    "\n",
+    "    \n",
+    "for panel, label in enumerate(\"uv\"):\n",
+    "\n",
+    "    ax = axs[panel + 3]\n",
+    "    \n",
+    "    ax.bar(\n",
+    "        [-0.5],\n",
+    "        m2_hexapod_correction_computed_uv[label],\n",
+    "        width=0.5\n",
+    "    )\n",
+    "    \n",
+    "    ax.bar(    \n",
+    "        [0.],\n",
+    "        m2_hexapod_correction_applied_uv[label],\n",
+    "        width=0.5\n",
+    "    )\n",
+    "\n",
+    "    ax.bar(    \n",
+    "        [0.5],\n",
+    "        m2_hexapod_correction_command_uv[label],\n",
+    "        width=0.5\n",
+    "    )\n",
+    "\n",
+    "    ax.set_xticks([0])\n",
+    "    ax.set_xticklabels([label])\n",
+    "    ax.set_ylabel(\"Position (degrees)\")\n",
+    "\n",
+    "\n",
+    "fig.suptitle(f\"{test_execution} - M2 Hexapod\\nComputed/Applied/Commanded Corrections\")\n",
+    "fig.tight_layout(h_pad=0.3)\n",
+    "fig.patch.set_facecolor('white')\n",
+    "\n",
+    "fig.savefig(f\"plots/{test_execution}_m2_hexapod.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d49c1971",
+   "metadata": {},
+   "source": [
+    "### Display M2 Correction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cec0c40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2_correction = await client.select_time_series(\n",
+    "    'lsst.sal.MTAOS.logevent_m2Correction', \n",
+    "    [f\"zForces{i}\" for i in range(72)], \n",
+    "    start.utc, \n",
+    "    end.utc\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "251e0cac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2_correction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8b628a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2_correction_applied = await client.select_time_series(\n",
+    "    'lsst.sal.MTM2.command_applyForces', \n",
+    "    [f\"axial{i}\" for i in range(72)], \n",
+    "    start.utc, \n",
+    "    end.utc\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e926da4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2_correction_applied"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9dbfb65b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(m2_correction.T)\n",
+    "plt.plot(m2_correction_applied.T)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79930b39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aa = np.loadtxt('%s/notebooks/M2_FEA/data/M2_1um_72_force.txt'%(os.environ[\"HOME\"]))\n",
+    "# to have +x going to right, and +y going up, we need to transpose and reverse x and y\n",
+    "m2_xact = -aa[:,2]\n",
+    "m2_yact = -aa[:,1]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdf3bb39-46e0-42e5-8a99-833a170ea7f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2_yact"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f94c60f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aa = np.array(m2_correction.T)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7652bf7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aa.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49735c92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2_correction.T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff1cb458",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m2_correction_applied.T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d201cec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(14,6))\n",
+    "\n",
+    "\n",
+    "for panel, timestamp in enumerate(m2_correction_applied.index):\n",
+    "    \n",
+    "    img = axes[panel].scatter(\n",
+    "        m2_xact, \n",
+    "        m2_yact, \n",
+    "        c=m2_correction_applied.T[timestamp], \n",
+    "        s=200, \n",
+    "        vmin=-1.5, \n",
+    "        vmax=1.5\n",
+    "    )\n",
+    "\n",
+    "    axes[panel].axis('equal')\n",
+    "\n",
+    "axes[0].set_title(\"+1um\")\n",
+    "axes[1].set_title(\"zero\")\n",
+    "axes[2].set_title(\"+2um\")\n",
+    "\n",
+    "fig.patch.set_facecolor('white')\n",
+    "fig.suptitle(f\"{test_execution} - Step 8\\nM2 Corrections\", x=0.435)\n",
+    "fig.tight_layout()\n",
+    "fig.colorbar(img, ax=axes, label=\"Correction [um]\", pad=0.01)\n",
+    "\n",
+    "fig.savefig(f\"plots/{test_execution}_m2.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "156dbc04",
+   "metadata": {},
+   "source": [
+    "### Display M1M3 Correction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6179ecb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "FATABLE_XPOSITION = 2\n",
+    "FATABLE_YPOSITION = 3\n",
+    "\n",
+    "FATABLE = np.array([\n",
+    "    [0,101,0.776782776,0,-2.158743,'SAA',3,1,'NA',-1,-1,0,-1],\n",
+    "    [1,102,1.442567993,0,-2.158743,'DAA',1,17,'+Y',-1,0,1,0],\n",
+    "    [2,103,2.10837793,0,-2.158743,'DAA',4,17,'+Y',-1,1,2,1],\n",
+    "    [3,104,2.774187988,0,-2.158743,'DAA',2,17,'+Y',-1,2,3,2],\n",
+    "    [4,105,3.439998047,0,-2.158743,'DAA',3,17,'+Y',-1,3,4,3],\n",
+    "    [5,106,3.968012939,0,-2.158743,'SAA',2,1,'NA',-1,-1,5,-1],\n",
+    "    [6,107,0.44386499,-0.57660498,-2.158743,'SAA',1,1,'NA',-1,-1,6,-1],\n",
+    "    [7,108,1.109675049,-0.57660498,-2.158743,'DAA',4,18,'+Y',-1,4,7,4],\n",
+    "    [8,109,1.775484985,-0.57660498,-2.158743,'DAA',2,18,'+Y',-1,5,8,5],\n",
+    "    [9,110,2.441295898,-0.57660498,-2.158743,'DAA',3,18,'+Y',-1,6,9,6],\n",
+    "    [10,111,3.107080078,-0.57660498,-2.158743,'DAA',1,18,'+Y',-1,7,10,7],\n",
+    "    [11,112,3.772891113,-0.57660498,-2.158743,'DAA',4,19,'-X',0,-1,11,8],\n",
+    "    [12,113,0,-1.153209961,-2.158743,'DAA',2,19,'+Y',-1,8,12,9],\n",
+    "    [13,114,0.776782776,-1.153209961,-2.158743,'DAA',3,19,'+Y',-1,9,13,10],\n",
+    "    [14,115,1.442567993,-1.153209961,-2.158743,'DAA',1,19,'+Y',-1,10,14,11],\n",
+    "    [15,116,2.10837793,-1.153209961,-2.158743,'DAA',4,20,'+Y',-1,11,15,12],\n",
+    "    [16,117,2.774187988,-1.153209961,-2.158743,'DAA',2,20,'+Y',-1,12,16,13],\n",
+    "    [17,118,3.439998047,-1.153209961,-2.158743,'DAA',3,20,'+Y',-1,13,17,14],\n",
+    "    [18,119,3.9005,-0.997687012,-2.158743,'SAA',2,2,'NA',-1,-1,18,-1],\n",
+    "    [19,120,0.44386499,-1.729819946,-2.158743,'DAA',1,20,'+Y',-1,14,19,15],\n",
+    "    [20,121,1.109675049,-1.729819946,-2.158743,'DAA',4,21,'+Y',-1,15,20,16],\n",
+    "    [21,122,1.775484985,-1.729819946,-2.158743,'DAA',2,21,'+Y',-1,16,21,17],\n",
+    "    [22,123,2.44127002,-1.729819946,-2.158743,'DAA',3,21,'+Y',-1,17,22,18],\n",
+    "    [23,124,3.107080078,-1.729819946,-2.158743,'DAA',1,21,'+Y',-1,18,23,19],\n",
+    "    [24,125,3.724452881,-1.517949951,-2.158743,'SAA',4,1,'NA',-1,-1,24,-1],\n",
+    "    [25,126,0,-2.306419922,-2.158743,'DAA',2,22,'+Y',-1,19,25,20],\n",
+    "    [26,127,0.776782776,-2.306419922,-2.158743,'DAA',3,22,'+Y',-1,20,26,21],\n",
+    "    [27,128,1.442567993,-2.306419922,-2.158743,'DAA',1,22,'-X',1,-1,27,22],\n",
+    "    [28,129,2.10837793,-2.306419922,-2.158743,'DAA',4,22,'+Y',-1,21,28,23],\n",
+    "    [29,130,2.774187988,-2.306419922,-2.158743,'DAA',2,23,'+Y',-1,22,29,24],\n",
+    "    [30,131,3.387954102,-2.167409912,-2.158743,'SAA',3,2,'NA',-1,-1,30,-1],\n",
+    "    [31,132,0.44386499,-2.883030029,-2.158743,'DAA',1,23,'+Y',-1,23,31,25],\n",
+    "    [32,133,1.109675049,-2.883030029,-2.158743,'DAA',4,23,'+Y',-1,24,32,26],\n",
+    "    [33,134,1.775484985,-2.883030029,-2.158743,'DAA',2,24,'+Y',-1,25,33,27],\n",
+    "    [34,135,2.44127002,-2.883030029,-2.158743,'DAA',3,23,'-X',2,-1,34,28],\n",
+    "    [35,136,2.939364014,-2.745179932,-2.158743,'SAA',4,2,'NA',-1,-1,35,-1],\n",
+    "    [36,137,0.221945206,-3.459629883,-2.158743,'DAA',2,25,'+Y',-1,26,36,29],\n",
+    "    [37,138,0.88772998,-3.459629883,-2.158743,'DAA',3,24,'+Y',-1,27,37,30],\n",
+    "    [38,139,1.553540039,-3.267429932,-2.158743,'SAA',1,2,'NA',-1,-1,38,-1],\n",
+    "    [39,140,2.089733887,-3.436389893,-2.158743,'SAA',4,3,'NA',-1,-1,39,-1],\n",
+    "    [40,141,0.365734589,-4.00525,-2.158743,'SAA',1,3,'NA',-1,-1,40,-1],\n",
+    "    [41,142,1.085088013,-3.87276001,-2.158743,'SAA',2,3,'NA',-1,-1,41,-1],\n",
+    "    [42,143,1.60401001,-3.692780029,-2.158743,'SAA',3,3,'NA',-1,-1,42,-1],\n",
+    "    [43,207,-0.44386499,-0.57660498,-2.158743,'SAA',1,4,'NA',-1,-1,43,-1],\n",
+    "    [44,208,-1.109680054,-0.57660498,-2.158743,'DAA',4,24,'+Y',-1,28,44,31],\n",
+    "    [45,209,-1.77548999,-0.57660498,-2.158743,'DAA',2,26,'+Y',-1,29,45,32],\n",
+    "    [46,210,-2.441300049,-0.57660498,-2.158743,'DAA',3,25,'+Y',-1,30,46,33],\n",
+    "    [47,211,-3.107080078,-0.57660498,-2.158743,'DAA',1,24,'+Y',-1,31,47,34],\n",
+    "    [48,212,-3.772889893,-0.57660498,-2.158743,'DAA',4,25,'+X',3,-1,48,35],\n",
+    "    [49,214,-0.77678302,-1.153209961,-2.158743,'DAA',3,26,'+Y',-1,32,49,36],\n",
+    "    [50,215,-1.442569946,-1.153209961,-2.158743,'DAA',1,25,'+Y',-1,33,50,37],\n",
+    "    [51,216,-2.108379883,-1.153209961,-2.158743,'DAA',4,26,'+Y',-1,34,51,38],\n",
+    "    [52,217,-2.774189941,-1.153209961,-2.158743,'DAA',2,27,'+Y',-1,35,52,39],\n",
+    "    [53,218,-3.44,-1.153209961,-2.158743,'DAA',3,27,'+Y',-1,36,53,40],\n",
+    "    [54,219,-3.9005,-0.997687012,-2.158743,'SAA',2,4,'NA',-1,-1,54,-1],\n",
+    "    [55,220,-0.44386499,-1.729819946,-2.158743,'DAA',1,26,'+Y',-1,37,55,41],\n",
+    "    [56,221,-1.109680054,-1.729819946,-2.158743,'DAA',4,27,'+Y',-1,38,56,42],\n",
+    "    [57,222,-1.77548999,-1.729819946,-2.158743,'DAA',2,28,'+Y',-1,39,57,43],\n",
+    "    [58,223,-2.44127002,-1.729819946,-2.158743,'DAA',3,28,'+Y',-1,40,58,44],\n",
+    "    [59,224,-3.107080078,-1.729819946,-2.158743,'DAA',1,27,'+Y',-1,41,59,45],\n",
+    "    [60,225,-3.724449951,-1.517949951,-2.158743,'SAA',4,4,'NA',-1,-1,60,-1],\n",
+    "    [61,227,-0.77678302,-2.306419922,-2.158743,'DAA',3,29,'+Y',-1,42,61,46],\n",
+    "    [62,228,-1.442569946,-2.306419922,-2.158743,'DAA',1,28,'+X',4,-1,62,47],\n",
+    "    [63,229,-2.108379883,-2.306419922,-2.158743,'DAA',4,28,'+Y',-1,43,63,48],\n",
+    "    [64,230,-2.774189941,-2.306419922,-2.158743,'DAA',2,29,'+Y',-1,44,64,49],\n",
+    "    [65,231,-3.387949951,-2.167409912,-2.158743,'SAA',3,4,'NA',-1,-1,65,-1],\n",
+    "    [66,232,-0.44386499,-2.883030029,-2.158743,'DAA',1,29,'+Y',-1,45,66,50],\n",
+    "    [67,233,-1.109680054,-2.883030029,-2.158743,'DAA',4,29,'+Y',-1,46,67,51],\n",
+    "    [68,234,-1.77548999,-2.883030029,-2.158743,'DAA',2,30,'+Y',-1,47,68,52],\n",
+    "    [69,235,-2.44127002,-2.883030029,-2.158743,'DAA',3,30,'+X',5,-1,69,53],\n",
+    "    [70,236,-2.939360107,-2.745179932,-2.158743,'SAA',4,5,'NA',-1,-1,70,-1],\n",
+    "    [71,237,-0.221945007,-3.459629883,-2.158743,'DAA',2,31,'+Y',-1,48,71,54],\n",
+    "    [72,238,-0.88772998,-3.459629883,-2.158743,'DAA',3,31,'+Y',-1,49,72,55],\n",
+    "    [73,239,-1.553540039,-3.267429932,-2.158743,'SAA',1,5,'NA',-1,-1,73,-1],\n",
+    "    [74,240,-2.08972998,-3.436389893,-2.158743,'SAA',4,6,'NA',-1,-1,74,-1],\n",
+    "    [75,241,-0.365734985,-4.00525,-2.158743,'SAA',1,6,'NA',-1,-1,75,-1],\n",
+    "    [76,242,-1.085089966,-3.87276001,-2.158743,'SAA',2,5,'NA',-1,-1,76,-1],\n",
+    "    [77,243,-1.60401001,-3.692780029,-2.158743,'SAA',3,5,'NA',-1,-1,77,-1],\n",
+    "    [78,301,-0.77678302,0,-2.158743,'SAA',3,6,'NA',-1,-1,78,-1],\n",
+    "    [79,302,-1.442569946,0,-2.158743,'DAA',1,30,'+Y',-1,50,79,56],\n",
+    "    [80,303,-2.108379883,0,-2.158743,'DAA',4,30,'+Y',-1,51,80,57],\n",
+    "    [81,304,-2.774189941,0,-2.158743,'DAA',2,32,'+Y',-1,52,81,58],\n",
+    "    [82,305,-3.44,0,-2.158743,'DAA',3,32,'+Y',-1,53,82,59],\n",
+    "    [83,306,-3.96801001,0,-2.158743,'SAA',2,6,'NA',-1,-1,83,-1],\n",
+    "    [84,307,-0.44386499,0.576605408,-2.158743,'SAA',1,7,'NA',-1,-1,84,-1],\n",
+    "    [85,308,-1.109680054,0.576605408,-2.158743,'DAA',4,31,'+Y',-1,54,85,60],\n",
+    "    [86,309,-1.77548999,0.576605408,-2.158743,'DAA',2,33,'+Y',-1,55,86,61],\n",
+    "    [87,310,-2.441300049,0.576605408,-2.158743,'DAA',3,33,'+Y',-1,56,87,62],\n",
+    "    [88,311,-3.107080078,0.576605408,-2.158743,'DAA',1,31,'-Y',-1,57,88,63],\n",
+    "    [89,312,-3.772889893,0.576605408,-2.158743,'DAA',4,32,'+X',6,-1,89,64],\n",
+    "    [90,313,0,1.15321106,-2.158743,'DAA',2,34,'+Y',-1,58,90,65],\n",
+    "    [91,314,-0.77678302,1.15321106,-2.158743,'DAA',3,34,'+Y',-1,59,91,66],\n",
+    "    [92,315,-1.442569946,1.15321106,-2.158743,'DAA',1,32,'+Y',-1,60,92,67],\n",
+    "    [93,316,-2.108379883,1.15321106,-2.158743,'DAA',4,33,'+Y',-1,61,93,68],\n",
+    "    [94,317,-2.774189941,1.15321106,-2.158743,'DAA',2,35,'+Y',-1,62,94,69],\n",
+    "    [95,318,-3.44,1.15321106,-2.158743,'DAA',3,35,'+Y',-1,63,95,70],\n",
+    "    [96,319,-3.9005,0.997686584,-2.158743,'SAA',2,7,'NA',-1,-1,96,-1],\n",
+    "    [97,320,-0.44386499,1.72981604,-2.158743,'DAA',1,33,'+Y',-1,64,97,71],\n",
+    "    [98,321,-1.109680054,1.72981604,-2.158743,'DAA',4,34,'+Y',-1,65,98,72],\n",
+    "    [99,322,-1.77548999,1.72981604,-2.158743,'DAA',2,36,'+Y',-1,66,99,73],\n",
+    "    [100,323,-2.44127002,1.72981604,-2.158743,'DAA',3,36,'+Y',-1,67,100,74],\n",
+    "    [101,324,-3.107080078,1.72981604,-2.158743,'DAA',1,34,'+Y',-1,68,101,75],\n",
+    "    [102,325,-3.724449951,1.517954956,-2.158743,'SAA',4,7,'NA',-1,-1,102,-1],\n",
+    "    [103,326,0,2.306422119,-2.158743,'DAA',2,37,'+Y',-1,69,103,76],\n",
+    "    [104,327,-0.77678302,2.306422119,-2.158743,'DAA',3,37,'+Y',-1,70,104,77],\n",
+    "    [105,328,-1.442569946,2.306422119,-2.158743,'DAA',1,35,'+X',7,-1,105,78],\n",
+    "    [106,329,-2.108379883,2.306422119,-2.158743,'DAA',4,35,'+Y',-1,71,106,79],\n",
+    "    [107,330,-2.774189941,2.306422119,-2.158743,'DAA',2,38,'+Y',-1,72,107,80],\n",
+    "    [108,331,-3.387949951,2.167406982,-2.158743,'SAA',3,7,'NA',-1,-1,108,-1],\n",
+    "    [109,332,-0.44386499,2.8830271,-2.158743,'DAA',1,36,'+Y',-1,73,109,81],\n",
+    "    [110,333,-1.109680054,2.8830271,-2.158743,'DAA',4,36,'+Y',-1,74,110,82],\n",
+    "    [111,334,-1.77548999,2.8830271,-2.158743,'DAA',2,39,'-Y',-1,75,111,83],\n",
+    "    [112,335,-2.44127002,2.8830271,-2.158743,'DAA',3,38,'+X',8,-1,112,84],\n",
+    "    [113,336,-2.939360107,2.745180908,-2.158743,'SAA',4,8,'NA',-1,-1,113,-1],\n",
+    "    [114,337,-0.221945007,3.45963208,-2.158743,'DAA',2,40,'+Y',-1,76,114,85],\n",
+    "    [115,338,-0.88772998,3.45963208,-2.158743,'DAA',3,39,'+Y',-1,77,115,86],\n",
+    "    [116,339,-1.553540039,3.267430908,-2.158743,'SAA',1,8,'NA',-1,-1,116,-1],\n",
+    "    [117,340,-2.08972998,3.436391113,-2.158743,'SAA',4,9,'NA',-1,-1,117,-1],\n",
+    "    [118,341,-0.365734985,4.00525,-2.158743,'SAA',1,9,'NA',-1,-1,118,-1],\n",
+    "    [119,342,-1.085089966,3.872762939,-2.158743,'SAA',2,8,'NA',-1,-1,119,-1],\n",
+    "    [120,343,-1.60401001,3.692779053,-2.158743,'SAA',3,8,'NA',-1,-1,120,-1],\n",
+    "    [121,407,0.44386499,0.576605408,-2.158743,'SAA',1,10,'NA',-1,-1,121,-1],\n",
+    "    [122,408,1.109675049,0.576605408,-2.158743,'DAA',4,37,'+Y',-1,78,122,87],\n",
+    "    [123,409,1.775484985,0.576605408,-2.158743,'DAA',2,41,'+Y',-1,79,123,88],\n",
+    "    [124,410,2.441295898,0.576605408,-2.158743,'DAA',3,40,'+Y',-1,80,124,89],\n",
+    "    [125,411,3.107080078,0.576605408,-2.158743,'DAA',1,37,'-Y',-1,81,125,90],\n",
+    "    [126,412,3.772891113,0.576605408,-2.158743,'DAA',4,38,'-X',9,-1,126,91],\n",
+    "    [127,414,0.776782776,1.15321106,-2.158743,'DAA',3,41,'+Y',-1,82,127,92],\n",
+    "    [128,415,1.442567993,1.15321106,-2.158743,'DAA',1,38,'+Y',-1,83,128,93],\n",
+    "    [129,416,2.10837793,1.15321106,-2.158743,'DAA',4,39,'+Y',-1,84,129,94],\n",
+    "    [130,417,2.774187988,1.15321106,-2.158743,'DAA',2,42,'+Y',-1,85,130,95],\n",
+    "    [131,418,3.439998047,1.15321106,-2.158743,'DAA',3,42,'+Y',-1,86,131,96],\n",
+    "    [132,419,3.9005,0.997686584,-2.158743,'SAA',2,9,'NA',-1,-1,132,-1],\n",
+    "    [133,420,0.44386499,1.72981604,-2.158743,'DAA',1,39,'+Y',-1,87,133,97],\n",
+    "    [134,421,1.109675049,1.72981604,-2.158743,'DAA',4,40,'+Y',-1,88,134,98],\n",
+    "    [135,422,1.775484985,1.72981604,-2.158743,'DAA',2,43,'+Y',-1,89,135,99],\n",
+    "    [136,423,2.44127002,1.72981604,-2.158743,'DAA',3,43,'+Y',-1,90,136,100],\n",
+    "    [137,424,3.107080078,1.72981604,-2.158743,'DAA',1,40,'+Y',-1,91,137,101],\n",
+    "    [138,425,3.724452881,1.517954956,-2.158743,'SAA',4,10,'NA',-1,-1,138,-1],\n",
+    "    [139,427,0.776782776,2.306422119,-2.158743,'DAA',3,44,'+Y',-1,92,139,102],\n",
+    "    [140,428,1.442567993,2.306422119,-2.158743,'DAA',1,41,'-X',10,-1,140,103],\n",
+    "    [141,429,2.10837793,2.306422119,-2.158743,'DAA',4,41,'+Y',-1,93,141,104],\n",
+    "    [142,430,2.774187988,2.306422119,-2.158743,'DAA',2,44,'+Y',-1,94,142,105],\n",
+    "    [143,431,3.387954102,2.167406982,-2.158743,'SAA',3,9,'NA',-1,-1,143,-1],\n",
+    "    [144,432,0.44386499,2.8830271,-2.158743,'DAA',1,42,'+Y',-1,95,144,106],\n",
+    "    [145,433,1.109675049,2.8830271,-2.158743,'DAA',4,42,'+Y',-1,96,145,107],\n",
+    "    [146,434,1.775484985,2.8830271,-2.158743,'DAA',2,45,'-Y',-1,97,146,108],\n",
+    "    [147,435,2.44127002,2.8830271,-2.158743,'DAA',3,45,'-X',11,-1,147,109],\n",
+    "    [148,436,2.939364014,2.745180908,-2.158743,'SAA',4,11,'NA',-1,-1,148,-1],\n",
+    "    [149,437,0.221945206,3.45963208,-2.158743,'DAA',2,46,'+Y',-1,98,149,110],\n",
+    "    [150,438,0.88772998,3.45963208,-2.158743,'DAA',3,46,'+Y',-1,99,150,111],\n",
+    "    [151,439,1.553540039,3.267430908,-2.158743,'SAA',1,11,'NA',-1,-1,151,-1],\n",
+    "    [152,440,2.089733887,3.436391113,-2.158743,'SAA',4,12,'NA',-1,-1,152,-1],\n",
+    "    [153,441,0.365734589,4.00525,-2.158743,'SAA',1,12,'NA',-1,-1,153,-1],\n",
+    "    [154,442,1.085088013,3.872762939,-2.158743,'SAA',2,10,'NA',-1,-1,154,-1],\n",
+    "    [155,443,1.60401001,3.692779053,-2.158743,'SAA',3,10,'NA',-1,-1,155,-1],\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7562455a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m1m3_xact = np.float64(FATABLE[:, FATABLE_XPOSITION])\n",
+    "m1m3_yact = np.float64(FATABLE[:, FATABLE_YPOSITION])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d91769c-9931-409b-a0be-16a8c04f1e07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m1m3_yact"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a283aff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m1m3_correction = await client.select_time_series(\n",
+    "    'lsst.sal.MTAOS.logevent_m1m3Correction', \n",
+    "    [f\"zForces{i}\" for i in range(156)], \n",
+    "    start.utc, \n",
+    "    end.utc\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22664be1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m1m3_correction_applied = await client.select_time_series(\n",
+    "    'lsst.sal.MTM1M3.command_applyActiveOpticForces', \n",
+    "    [f\"zForces{i}\" for i in range(156)], \n",
+    "    start.utc, \n",
+    "    end.utc\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4ce9be6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m1m3_correction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d679edd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m1m3_correction_applied"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "686291c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(17, 7))\n",
+    "\n",
+    "for ax, time in zip(axes.flatten(), m1m3_correction.T):\n",
+    "    img = ax.scatter(m1m3_xact, m1m3_yact, c=m1m3_correction.T[time], s=150, vmin=-30, vmax=30)\n",
+    "    ax.axis('equal')\n",
+    "    ax.set_title(f\"applied forces\\n{time}\")\n",
+    "\n",
+    "fig.patch.set_facecolor('white')\n",
+    "fig.suptitle(f\"{test_execution} - Step 9\\nM1 Corrections\", x=0.43)\n",
+    "fig.tight_layout()\n",
+    "fig.colorbar(img, ax=axes, label=\"Correction [um]\", pad=0.01)\n",
+    "fig.savefig(f\"plots/{test_execution}_m1.png\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0a1d5e0-bded-4629-94c1-96a3fd543bfa",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77dada0e-dcc6-40a8-a1f5-dfd921ed7465",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
New PR to start fresh.

In this one, I add the notebook provided by Tiago to the `procedures/` folder. The notebook grabs data from the EFD and runs multiple plots to help understand and evaluate if the LVV-T2190 test was successful or not. 

I added some documentation at the beginning of the notebook and did some small improvements to the cells that run the plots. Other than this, the notebook is basically the same as the original. 